### PR TITLE
Fix local ollama

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -14,8 +14,9 @@ const OPENAI_MODELS = [
   "gpt-4o",
 ];
 
+// https://github.com/ollama/ollama/blob/main/docs/faq.md#where-are-models-stored
 const OLLAMA_MODELS_PATH = {
-  Darwin: "~/.ollama/models",
+  Darwin: `${process.env.HOME}/.ollama/models`,
   Linux: "/usr/share/ollama/.ollama/models",
   Windows_NT: "C:\\Users\\%username%\\.ollama\\models."
 }

--- a/constants.js
+++ b/constants.js
@@ -14,4 +14,10 @@ const OPENAI_MODELS = [
   "gpt-4o",
 ];
 
-module.exports = { OPENAI_MODELS };
+const OLLAMA_MODELS_PATH = {
+  Darwin: "~/.ollama/models",
+  Linux: "/usr/share/ollama/.ollama/models",
+  Windows_NT: "C:\\Users\\%username%\\.ollama\\models."
+}
+
+module.exports = { OPENAI_MODELS, OLLAMA_MODELS_PATH };

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,17 @@
+const OPENAI_MODELS = [
+  "gpt-3.5-turbo",
+  "gpt-3.5-turbo-16k",
+  "gpt-3.5-turbo-1106",
+  "gpt-3.5-turbo-0125",
+  "gpt-3.5-turbo-0613",
+  "gpt-3.5-turbo-16k-0613",
+  "gpt-4",
+  "gpt-4-32k",
+  "gpt-4-turbo-preview",
+  "gpt-4-1106-preview",
+  "gpt-4-0125-preview",
+  "gpt-4-turbo",
+  "gpt-4o",
+];
+
+module.exports = { OPENAI_MODELS };

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const Workflow = require("@saltcorn/data/models/workflow");
 const Form = require("@saltcorn/data/models/form");
-const { getCompletion, getEmbedding } = require("./generate");
 const db = require("@saltcorn/data/db");
+const { getCompletion, getEmbedding } = require("./generate");
+const { OPENAI_MODELS } = require("./constants.js");
 
 const configuration_workflow = () =>
   new Workflow({
@@ -55,21 +56,7 @@ const configuration_workflow = () =>
                 required: true,
                 showIf: { backend: "OpenAI" },
                 attributes: {
-                  options: [
-                    "gpt-3.5-turbo",
-                    "gpt-3.5-turbo-16k",
-                    "gpt-3.5-turbo-1106",
-                    "gpt-3.5-turbo-0125",
-                    "gpt-3.5-turbo-0613",
-                    "gpt-3.5-turbo-16k-0613",
-                    "gpt-4",
-                    "gpt-4-32k",
-                    "gpt-4-turbo-preview",
-                    "gpt-4-1106-preview",
-                    "gpt-4-0125-preview",
-                    "gpt-4-turbo",
-                    "gpt-4o",
-                  ],
+                  options: OPENAI_MODELS,
                 },
               },
               {

--- a/index.js
+++ b/index.js
@@ -60,6 +60,8 @@ const configuration_workflow = () =>
                     "gpt-3.5-turbo-16k",
                     "gpt-3.5-turbo-1106",
                     "gpt-3.5-turbo-0125",
+                    "gpt-3.5-turbo-0613",
+                    "gpt-3.5-turbo-16k-0613",
                     "gpt-4",
                     "gpt-4-32k",
                     "gpt-4-turbo-preview",
@@ -122,7 +124,7 @@ const configuration_workflow = () =>
                 label: "Embedding endpoint",
                 type: "String",
                 sublabel:
-                  "Optional. Use an alternative OpenAI-compatible API for embeddings. Example: http://127.0.0.1:8080/v1/embeddings",
+                  "Optional. Example: http://localhost:11434/api/embeddings",
                 showIf: { backend: "Local Ollama" },
               },
             ],

--- a/model.js
+++ b/model.js
@@ -12,7 +12,7 @@ const fs = require("fs");
 const _ = require("underscore");
 
 const { getCompletion } = require("./generate");
-const { OLLAMA_MODELS_PATH } = require("./constants");
+const { OPENAI_MODELS, OLLAMA_MODELS_PATH } = require("./constants");
 
 const configuration_workflow = (config) => (req) =>
   new Workflow({

--- a/model.js
+++ b/model.js
@@ -12,6 +12,7 @@ const fs = require("fs");
 const _ = require("underscore");
 
 const { getCompletion } = require("./generate");
+const { OLLAMA_MODELS_PATH } = require("./constants");
 
 const configuration_workflow = (config) => (req) =>
   new Workflow({
@@ -34,8 +35,7 @@ const configuration_workflow = (config) => (req) =>
           } else if (config.backend === "OpenAI") {
             models = OPENAI_MODELS;
           } else if (config.backend === "Local Ollama") {
-            models = fs.readdirSync("~/.ollama/models/manifests/registry.ollama.ai/library");
-            // models = fs.readdirSync(path.join(config.ollama_dir, "models"));
+            models = fs.readdirSync(path.join(OLLAMA_MODELS_PATH[os.type()], "manifests/registry.ollama.ai/library"));
           }
           return new Form({
             fields: [

--- a/model.js
+++ b/model.js
@@ -45,6 +45,8 @@ const configuration_workflow = (config) => (req) =>
               "gpt-4-turbo",
               "gpt-4o",
             ];
+          } else if (config.backend === "Local Ollama") {
+            // models = fs.readdirSync(path.join(config.ollama_dir, "models")); TODO: something like ~/.ollama/models/manifests/registry.ollama.ai/library
           }
           return new Form({
             fields: [
@@ -109,7 +111,7 @@ const modelpatterns = (config) => ({
               name: "repeat_penalty",
               label: "Repeat penalty",
               type: "Float",
-              attributes: { min: 0 },
+              attributes: { min: 0, decimal_places: 1 },
               default: 1.1,
             },
           ]
@@ -118,7 +120,7 @@ const modelpatterns = (config) => ({
         name: "temp",
         label: "Temperature",
         type: "Float",
-        attributes: { min: 0 },
+        attributes: { min: 0, max: 1, decimal_places: 1 },
         default: 0.8,
       },
     ],

--- a/model.js
+++ b/model.js
@@ -32,21 +32,10 @@ const configuration_workflow = (config) => (req) =>
           if (config.backend === "Local llama.cpp") {
             models = fs.readdirSync(path.join(config.llama_dir, "models"));
           } else if (config.backend === "OpenAI") {
-            models = [
-              "gpt-3.5-turbo",
-              "gpt-3.5-turbo-16k",
-              "gpt-3.5-turbo-1106",
-              "gpt-3.5-turbo-0125",
-              "gpt-4",
-              "gpt-4-32k",
-              "gpt-4-turbo-preview",
-              "gpt-4-1106-preview",
-              "gpt-4-0125-preview",
-              "gpt-4-turbo",
-              "gpt-4o",
-            ];
+            models = OPENAI_MODELS;
           } else if (config.backend === "Local Ollama") {
-            // models = fs.readdirSync(path.join(config.ollama_dir, "models")); TODO: something like ~/.ollama/models/manifests/registry.ollama.ai/library
+            models = fs.readdirSync("~/.ollama/models/manifests/registry.ollama.ai/library");
+            // models = fs.readdirSync(path.join(config.ollama_dir, "models"));
           }
           return new Form({
             fields: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saltcorn/large-language-model",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Large language models and functionality for Saltcorn",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
1. When setting Local Ollama as the llm backend and trying to setup a model, the "model" field will have no available options while remain to be required.
<img width="569" alt="image" src="https://github.com/saltcorn/large-language-model/assets/15627635/d9b08b34-60eb-46a7-815a-f7c2342cf0ea">

2. Move OpenAI to a standalone `constants.js` file. (Do we want to keep the OpenAI model list up-to-date? (https://platform.openai.com/docs/api-reference/models/list))